### PR TITLE
share http client & close body

### DIFF
--- a/common/sas.go
+++ b/common/sas.go
@@ -216,7 +216,7 @@ type EdgeSignRequestResponse struct {
 var sharedUnixHTTPClient http.Client
 var doOnce sync.Once
 
-func setSharedUnixHTTPClient(addrName string) http.Client {
+func setSharedUnixHTTPClient(addrName string) {
 	doOnce.Do(func() {
 		sharedUnixHTTPClient = http.Client{
 			Transport: &http.Transport{
@@ -226,8 +226,6 @@ func setSharedUnixHTTPClient(addrName string) http.Client {
 			},
 		}
 	})
-
-	return sharedUnixHTTPClient
 }
 
 func edgeSignRequest(workloadURI, name, genid string, payload *EdgeSignRequestPayload) (string, error) {


### PR DESCRIPTION
Created with @batslyadams @sujitdmello @giventocode

This PR fixes 2 bugs:
(1) In `edgeSignRequest` the response body is never closed, causing resource leaks.
(2) In `edgeSignRequest` each function call uses its own http client. This causes thousands of connections, and eventually crashes our module and the iotedge runtime within a few minutes. It exhausts the pool of sockets on a ubuntu based linux vm.

With this PR:
(1) The response body is closed.
(2) The http client is initialized once and shared thereafter.

Here is a picture of the new behavior, where only a few connections are made:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/10049607/98041178-858e0b00-1def-11eb-87c2-9e59de79ab98.png)

Before this PR, after about ~5 minutes, there were over 3600 unix connections which eventually exhausted the resources.

@haylesnortal, would you be able to give this a review? We want to merge this so we can reference it in the telegraf module, [instead of using a fork](https://github.com/michaelperel/telegraf/blob/ga-azure-iot-2/go.mod#L163). Thanks :)