### PR TITLE
Add Queue Purge method to service client

### DIFF
--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -645,6 +645,7 @@ func (c *Client) callMethod(ctx context.Context, path string, call *MethodCall) 
 		nil,
 		call,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -662,10 +663,26 @@ func (c *Client) GetDevice(ctx context.Context, deviceID string) (*Device, error
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
 	return &res, nil
+}
+
+func (c *Client) PurgeQueue(ctx context.Context, deviceID string) (*PurgeMessageQueueResult, error) {
+	var res PurgeMessageQueueResult
+	_, err := c.call(
+		ctx,
+		http.MethodDelete,
+		pathf("devices/%s/commands", deviceID),
+		nil,
+		nil,
+		nil,
+		&res,
+		"2020-05-31-preview",
+	)
+	return &res, err
 }
 
 // CreateDevice creates a new device.
@@ -679,6 +696,7 @@ func (c *Client) CreateDevice(ctx context.Context, device *Device) (*Device, err
 		nil,
 		device,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -740,6 +758,7 @@ func (c *Client) bulkRequest(
 		nil,
 		devs,
 		&res,
+		"",
 	)
 	if err != nil {
 		if re, ok := err.(*RequestError); ok && re.Code == http.StatusBadRequest {
@@ -786,6 +805,7 @@ func (c *Client) UpdateDevice(ctx context.Context, device *Device) (*Device, err
 		ifMatchHeader(device.ETag),
 		device,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -802,6 +822,7 @@ func (c *Client) DeleteDevice(ctx context.Context, device *Device) error {
 		ifMatchHeader(device.ETag),
 		nil,
 		nil,
+		"",
 	)
 	return err
 }
@@ -817,6 +838,7 @@ func (c *Client) ListDevices(ctx context.Context) ([]*Device, error) {
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -834,6 +856,7 @@ func (c *Client) ListModules(ctx context.Context, deviceID string) ([]*Module, e
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -850,6 +873,7 @@ func (c *Client) CreateModule(ctx context.Context, module *Module) (*Module, err
 		nil,
 		module,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -869,6 +893,7 @@ func (c *Client) GetModule(ctx context.Context, deviceID, moduleID string) (
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -886,6 +911,7 @@ func (c *Client) UpdateModule(ctx context.Context, module *Module) (*Module, err
 		ifMatchHeader(module.ETag),
 		module,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -902,6 +928,7 @@ func (c *Client) DeleteModule(ctx context.Context, module *Module) error {
 		ifMatchHeader(module.ETag),
 		nil,
 		nil,
+		"",
 	)
 	return err
 }
@@ -917,6 +944,7 @@ func (c *Client) GetDeviceTwin(ctx context.Context, deviceID string) (*Twin, err
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -936,6 +964,7 @@ func (c *Client) GetModuleTwin(ctx context.Context, deviceID, moduleID string) (
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -953,6 +982,7 @@ func (c *Client) UpdateDeviceTwin(ctx context.Context, twin *Twin) (*Twin, error
 		ifMatchHeader(twin.ETag),
 		twin,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -972,6 +1002,7 @@ func (c *Client) UpdateModuleTwin(ctx context.Context, twin *ModuleTwin) (
 		ifMatchHeader(twin.ETag),
 		twin,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -989,6 +1020,7 @@ func (c *Client) ListConfigurations(ctx context.Context) ([]*Configuration, erro
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1008,6 +1040,7 @@ func (c *Client) CreateConfiguration(ctx context.Context, config *Configuration)
 		nil,
 		config,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1027,6 +1060,7 @@ func (c *Client) GetConfiguration(ctx context.Context, configID string) (
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1046,6 +1080,7 @@ func (c *Client) UpdateConfiguration(ctx context.Context, config *Configuration)
 		ifMatchHeader(config.ETag),
 		config,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1062,6 +1097,7 @@ func (c *Client) DeleteConfiguration(ctx context.Context, config *Configuration)
 		ifMatchHeader(config.ETag),
 		nil,
 		nil,
+		"",
 	)
 	return err
 }
@@ -1079,6 +1115,7 @@ func (c *Client) ApplyConfigurationContentOnDevice(
 		nil,
 		content,
 		nil,
+		"",
 	)
 	return err
 }
@@ -1135,6 +1172,7 @@ QueryNext:
 		h,
 		req,
 		&res,
+		"",
 	)
 	if err != nil {
 		return err
@@ -1159,6 +1197,7 @@ func (c *Client) Stats(ctx context.Context) (*Stats, error) {
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1178,6 +1217,7 @@ func (c *Client) CreateJob(ctx context.Context, job *Job) (map[string]interface{
 		nil,
 		job,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1195,6 +1235,7 @@ func (c *Client) ListJobs(ctx context.Context) ([]map[string]interface{}, error)
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1211,6 +1252,7 @@ func (c *Client) GetJob(ctx context.Context, jobID string) (map[string]interface
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1227,6 +1269,7 @@ func (c *Client) CancelJob(ctx context.Context, jobID string) (map[string]interf
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1279,6 +1322,7 @@ func (c *Client) GetJobV2(ctx context.Context, jobID string) (*JobV2, error) {
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1295,6 +1339,7 @@ func (c *Client) CancelJobV2(ctx context.Context, jobID string) (*JobV2, error) 
 		nil,
 		nil,
 		&res,
+		"",
 	); err != nil {
 		return nil, err
 	}
@@ -1311,6 +1356,7 @@ func (c *Client) CreateJobV2(ctx context.Context, job *JobV2) (*JobV2, error) {
 		nil,
 		job,
 		&res,
+		"",
 	)
 	if err != nil {
 		return nil, err
@@ -1325,6 +1371,7 @@ func (c *Client) call(
 	vals url.Values,
 	headers http.Header,
 	r, v interface{}, // request and response objects
+	apiVersion string,
 ) (http.Header, error) {
 	var br io.Reader
 	if r != nil {
@@ -1334,7 +1381,12 @@ func (c *Client) call(
 		}
 		br = bytes.NewReader(b)
 	}
-	q := url.Values{"api-version": []string{"2019-03-30"}}
+	q := make(url.Values)
+	if apiVersion == "" {
+		q.Add("api-version", "2019-03-30")
+	} else {
+		q.Add("api-version", apiVersion)
+	}
 	for k, vv := range vals {
 		for _, v := range vv {
 			q.Add(k, v)

--- a/iotservice/client_test.go
+++ b/iotservice/client_test.go
@@ -297,6 +297,16 @@ func TestGetModuleTwin(t *testing.T) {
 	}
 }
 
+func TestPurgeQueue(t *testing.T) {
+	client := newClient(t)
+	device, _ := newDeviceAndModule(t, client)
+	if _, err := client.PurgeQueue(
+		context.Background(), device.DeviceID,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestUpdateModuleTwin(t *testing.T) {
 	client := newClient(t)
 	device, module := newDeviceAndModule(t, client)

--- a/iotservice/registry.go
+++ b/iotservice/registry.go
@@ -46,6 +46,12 @@ type Device struct {
 	Capabilities               map[string]interface{} `json:"capabilities,omitempty"`
 }
 
+type PurgeMessageQueueResult struct {
+	DeviceID string `json:"deviceID,omitempty"`
+	ModuleID string `json:"moduleID,omitempty"`
+	TotalMessagesPurged int `json:"totalMessagesPurged,omitempty"`
+}
+
 type Module struct {
 	ModuleID                   string          `json:"moduleId,omitempty"`
 	DeviceID                   string          `json:"deviceId,omitempty"`

--- a/iotservice/registry.go
+++ b/iotservice/registry.go
@@ -47,9 +47,9 @@ type Device struct {
 }
 
 type PurgeMessageQueueResult struct {
-	DeviceID string `json:"deviceID,omitempty"`
-	ModuleID string `json:"moduleID,omitempty"`
-	TotalMessagesPurged int `json:"totalMessagesPurged,omitempty"`
+	DeviceID            string `json:"deviceID,omitempty"`
+	ModuleID            string `json:"moduleID,omitempty"`
+	TotalMessagesPurged int    `json:"totalMessagesPurged,omitempty"`
 }
 
 type Module struct {


### PR DESCRIPTION
This PR adds the [Queue Purge API method](https://docs.microsoft.com/en-us/rest/api/iothub/service/cloudtodevicemessages/purgecloudtodevicemessagequeue) to the service client. 

As this method was a more recent addition to the APIs than the version that the library is currently based on, I also updated the `call` func to take an `apiVersion` parameter which defaults to the version that the library is currently using. 