### PR TITLE
Add support for bulk updating of device twins.

### DIFF
--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -729,6 +729,17 @@ func (c *Client) UpdateDevices(
 	return c.bulkRequest(ctx, devices, op)
 }
 
+// UpdateDeviceTwins updates an array of device twins or tags in bulk mode.
+func (c *Client) UpdateDeviceTwins(
+	ctx context.Context, devices []*Device, force bool,
+) (*BulkResult, error) {
+	op := "UpdateTwinIfMatchETag"
+	if force {
+		op = "UpdateTwin"
+	}
+	return c.bulkRequest(ctx, devices, op)
+}
+
 // DeleteDevices deletes array of devices in bulk mode.
 func (c *Client) DeleteDevices(
 	ctx context.Context, devices []*Device, force bool,

--- a/iotservice/client_test.go
+++ b/iotservice/client_test.go
@@ -77,8 +77,8 @@ func TestETags(t *testing.T) {
 func TestBulkOperations(t *testing.T) {
 	client := newClient(t)
 	devices := []*Device{
-		{DeviceID: "test-bulk-0"},
-		{DeviceID: "test-bulk-1"},
+		{DeviceID: "test-bulk-0", Tags: map[string]interface{}{"tag-1": true}},
+		{DeviceID: "test-bulk-1", Tags: map[string]interface{}{"tag-2": true}},
 	}
 	for _, dev := range devices {
 		_ = client.DeleteDevice(context.Background(), dev)
@@ -93,6 +93,14 @@ func TestBulkOperations(t *testing.T) {
 	}
 
 	res, err = client.UpdateDevices(context.Background(), devices, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsSuccessful {
+		t.Fatal("update is not successful")
+	}
+
+	res, err = client.UpdateDeviceTwins(context.Background(), devices, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/iotservice/registry.go
+++ b/iotservice/registry.go
@@ -45,6 +45,7 @@ type Device struct {
 	Authentication             *Authentication        `json:"authentication,omitempty"`
 	Capabilities               map[string]interface{} `json:"capabilities,omitempty"`
 	Tags                       map[string]interface{} `json:"tags,omitempty"`
+	Properties                 *Properties            `json:"properties,omitempty"`
 }
 
 type PurgeMessageQueueResult struct {


### PR DESCRIPTION
Same method as UpdateDevices, just a different operation tag.  Allows
bulk updates of Device.Tags and Device.Properties.