### PR TITLE
Fixes D2C properties encoding

### DIFF
--- a/iotdevice/transport/mqtt/mqtt.go
+++ b/iotdevice/transport/mqtt/mqtt.go
@@ -474,6 +474,12 @@ func parseTwinPropsTopic(s string) (int, int, int, error) {
 	return rc, int(rid), ver, nil
 }
 
+func encodeProperties(props url.Values) string {
+	enc := props.Encode()
+
+	return strings.ReplaceAll(enc, "+", "%20")
+}
+
 const rfc3339Milli = "2006-01-02T15:04:05.999Z07:00"
 
 func (tr *Transport) Send(ctx context.Context, msg *common.Message) error {
@@ -503,7 +509,7 @@ func (tr *Transport) Send(ctx context.Context, msg *common.Message) error {
 		u.Add(k, v)
 	}
 
-	dst := "devices/" + tr.did + "/messages/events/" + u.Encode()
+	dst := "devices/" + tr.did + "/messages/events/" + encodeProperties(u)
 	qos := DefaultQoS
 	if q, ok := msg.TransportOptions["qos"]; ok {
 		qos = q.(int) // panic if it's not an int

--- a/iotdevice/transport/mqtt/mqtt_test.go
+++ b/iotdevice/transport/mqtt/mqtt_test.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -44,5 +45,28 @@ func TestParseTwinPropsTopic(t *testing.T) {
 		t.Errorf("ParseTwinPropsTopic(%q) = %d, %d, %d, _, want %d, %d, %d, _",
 			s, c, r, v, 200, 0x12, 4,
 		)
+	}
+}
+
+func TestEncodePropertiesHandleSpaces(t *testing.T) {
+	var cases = []struct {
+		key      string
+		value    string
+		expected string
+	}{
+		{" ", " ", "%20=%20"},
+		{"#", "#", "%23=%23"},
+		{"+", "+", "%2B=%2B"},
+	}
+
+	for _, c := range cases {
+		u := make(url.Values, 1)
+		u.Add(c.key, c.value)
+
+		enc := encodeProperties(u)
+
+		if enc != c.expected {
+			t.Errorf("encodeProperies(%v) = `%s`, want `%s`", u, enc, c.expected)
+		}
 	}
 }


### PR DESCRIPTION
Ensures that topic name for D2C messages does not contain wildcards.