### PR TITLE
File Upload Over HTTP

### DIFF
--- a/cmd/iothub-device/main.go
+++ b/cmd/iothub-device/main.go
@@ -289,7 +289,12 @@ func uploadFile(ctx context.Context, c *iotdevice.Client, args []string) error {
 	}
 	defer file.Close()
 
-	err = c.UploadFile(ctx, blobName, file)
+	stat, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+
+	err = c.UploadFile(ctx, blobName, file, stat.Size())
 	if err != nil {
 		return err
 	}

--- a/cmd/iothub-device/main.go
+++ b/cmd/iothub-device/main.go
@@ -64,7 +64,7 @@ func main() {
 }
 
 const help = `iothub-device helps iothub devices to communicate with the cloud.
-$IOTHUB_DEVICE_CONNECTION_STRING environment variable is required unless you use x509 authentication.`
+ $IOTHUB_DEVICE_CONNECTION_STRING environment variable is required unless you use x509 authentication.`
 
 func run() error {
 	ctx := context.Background()
@@ -298,14 +298,6 @@ func uploadFile(ctx context.Context, c *iotdevice.Client, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// if err := c.UploadFile(ctx, uploadContext, file); err != nil {
-	// 	return err
-	// }
-
-	// if err := c.NotifyFileUpload(ctx, uploadContext); err != nil {
-	// 	return err
-	// }
 
 	return nil
 }

--- a/cmd/iothub-service/main.go
+++ b/cmd/iothub-service/main.go
@@ -1086,7 +1086,6 @@ func watchFeedback(ctx context.Context, c *iotservice.Client, args []string) err
 
 func watchFileNotifications(ctx context.Context, c *iotservice.Client, args []string) error {
 	return c.SubscribeFileNotifications(ctx, func(f *iotservice.FileNotification) error {
-		fmt.Println(f)
 		return output(f, nil)
 	})
 }

--- a/cmd/iothub-service/main.go
+++ b/cmd/iothub-service/main.go
@@ -104,7 +104,7 @@ func main() {
 	}
 }
 
-const help = `Helps with interacting and managing your iothub devices. 
+const help = `Helps with interacting and managing your iothub devices.
 The $IOTHUB_SERVICE_CONNECTION_STRING environment variable is required for authentication.`
 
 func run() error {
@@ -1086,6 +1086,7 @@ func watchFeedback(ctx context.Context, c *iotservice.Client, args []string) err
 
 func watchFileNotifications(ctx context.Context, c *iotservice.Client, args []string) error {
 	return c.SubscribeFileNotifications(ctx, func(f *iotservice.FileNotification) error {
+		fmt.Println(f)
 		return output(f, nil)
 	})
 }

--- a/iotdevice/client.go
+++ b/iotdevice/client.go
@@ -378,11 +378,11 @@ func (c *Client) UploadFile(ctx context.Context, blobName string, file io.Reader
 		return err
 	}
 
-	err = c.tr.UploadFile(ctx, sas, file, size)
+	err = c.tr.UploadToBlob(ctx, sas, file, size)
 	if err == nil {
-		err = c.tr.NotifyFileUpload(ctx, correlationID, true, http.StatusOK, "File uploaded successfully")
+		err = c.tr.NotifyUploadComplete(ctx, correlationID, true, http.StatusOK, "File uploaded successfully")
 	} else {
-		notifyErr := c.tr.NotifyFileUpload(ctx, correlationID, false, http.StatusInternalServerError, "File upload failed")
+		notifyErr := c.tr.NotifyUploadComplete(ctx, correlationID, false, http.StatusInternalServerError, "File upload failed")
 		if notifyErr != nil {
 			err = fmt.Errorf("failed to notify file upload: %v - %w", notifyErr, err)
 		}

--- a/iotdevice/client.go
+++ b/iotdevice/client.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -363,4 +365,24 @@ func (c *Client) Close() error {
 		c.tsMux.close(ErrClosed)
 		return c.tr.Close()
 	}
+}
+
+func (c *Client) UploadFile(ctx context.Context, blobName string, file io.Reader) error {
+	if err := c.checkConnection(ctx); err != nil {
+		return err
+	}
+
+	correlationID, sas, err := c.tr.GetBlobSharedAccessSignature(ctx, blobName)
+	if err != nil {
+		return err
+	}
+
+	err = c.tr.UploadFile(ctx, sas, file)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(correlationID)
+
+	return nil
 }

--- a/iotdevice/client.go
+++ b/iotdevice/client.go
@@ -368,7 +368,7 @@ func (c *Client) Close() error {
 	}
 }
 
-func (c *Client) UploadFile(ctx context.Context, blobName string, file io.Reader) error {
+func (c *Client) UploadFile(ctx context.Context, blobName string, file io.Reader, size int64) error {
 	if err := c.checkConnection(ctx); err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (c *Client) UploadFile(ctx context.Context, blobName string, file io.Reader
 		return err
 	}
 
-	err = c.tr.UploadFile(ctx, sas, file)
+	err = c.tr.UploadFile(ctx, sas, file, size)
 	if err == nil {
 		err = c.tr.NotifyFileUpload(ctx, correlationID, true, http.StatusOK, "File uploaded successfully")
 	} else {

--- a/iotdevice/transport/http/http.go
+++ b/iotdevice/transport/http/http.go
@@ -62,26 +62,32 @@ func (tr *Transport) Connect(ctx context.Context, creds transport.Credentials) e
 	return nil
 }
 
+// Send is not available in the HTTP transport.
 func (tr *Transport) Send(ctx context.Context, msg *common.Message) error {
 	return ErrNotImplemented
 }
 
+// RegisterDirectMethods is not available in the HTTP transport.
 func (tr *Transport) RegisterDirectMethods(ctx context.Context, mux transport.MethodDispatcher) error {
 	return ErrNotImplemented
 }
 
+// SubscribeEvents is not available in the HTTP transport.
 func (tr *Transport) SubscribeEvents(ctx context.Context, mux transport.MessageDispatcher) error {
 	return ErrNotImplemented
 }
 
+// SubscribeTwinUpdates is not available in the HTTP transport.
 func (tr *Transport) SubscribeTwinUpdates(ctx context.Context, mux transport.TwinStateDispatcher) error {
 	return ErrNotImplemented
 }
 
+// RetrieveTwinProperties is not available in the HTTP transport.
 func (tr *Transport) RetrieveTwinProperties(ctx context.Context) (payload []byte, err error) {
 	return nil, ErrNotImplemented
 }
 
+// UpdateTwinProperties is not available in the HTTP transport.
 func (tr *Transport) UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error) {
 	return 0, ErrNotImplemented
 }
@@ -95,7 +101,8 @@ func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName 
 		return "", "", err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://localhost:443/devices/%s/files", tr.creds.GetDeviceID()), bytes.NewReader(body))
+	target := fmt.Sprintf("https://%s/devices/%s/files", tr.creds.GetHostName(), tr.creds.GetDeviceID())
+	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
 	if err != nil {
 		return "", "", err
 	}
@@ -112,11 +119,44 @@ func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName 
 		return "", "", err
 	}
 
+	// TODO: check response body, http code
+
 	return response.CorrelationID, response.SASURI(), nil
 }
 
 func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader) error {
 	req, err := http.NewRequest(http.MethodPut, sasURI, file)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("x-ms-blob-type", "BlockBlob")
+
+	resp, err := tr.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (tr *Transport) NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
+	payload := NotifyFileUploadRequest{
+		CorrelationID:     correlationID,
+		IsSuccess:         success,
+		StatusCode:        statusCode,
+		StatusDescription: statusDescription,
+	}
+	body, err := json.Marshal(&payload)
+	if err != nil {
+		return err
+	}
+
+	target := fmt.Sprintf("https://%s/devices/%s/files/notifications", tr.creds.GetHostName(), tr.creds.GetDeviceID())
+	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -126,7 +166,7 @@ func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Read
 		return err
 	}
 
-	// TODO: Check response body, code
+	// TODO: check response body, http code
 
 	return nil
 }

--- a/iotdevice/transport/http/http.go
+++ b/iotdevice/transport/http/http.go
@@ -96,7 +96,7 @@ func (tr *Transport) UpdateTwinProperties(ctx context.Context, payload []byte) (
 }
 
 func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error) {
-	payload := CreateFileUploadRequest{
+	payload := BlobSharedAccessSignatureRequest{
 		BlobName: blobName,
 	}
 	body, err := json.Marshal(&payload)
@@ -137,18 +137,16 @@ func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName 
 		return "", "", fmt.Errorf("code = %d, message = %s, exception message = %s", resp.StatusCode, response.Message, response.ExceptionMessage)
 	}
 
-	var response CreateFileUploadResponse
+	var response BlobSharedAccessSignatureResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		return "", "", err
 	}
 
-	// TODO: check response body, http code
-
 	return response.CorrelationID, response.SASURI(), nil
 }
 
-func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader, size int64) error {
+func (tr *Transport) UploadToBlob(ctx context.Context, sasURI string, file io.Reader, size int64) error {
 	req, err := http.NewRequest(http.MethodPut, sasURI, file)
 	if err != nil {
 		return err
@@ -168,8 +166,8 @@ func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Read
 	return nil
 }
 
-func (tr *Transport) NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
-	payload := NotifyFileUploadRequest{
+func (tr *Transport) NotifyUploadComplete(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
+	payload := NotifyUploadCompleteRequest{
 		IsSuccess:         success,
 		StatusCode:        statusCode,
 		StatusDescription: statusDescription,

--- a/iotdevice/transport/http/http.go
+++ b/iotdevice/transport/http/http.go
@@ -1,0 +1,137 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/amenzhinsky/iothub/common"
+	"github.com/amenzhinsky/iothub/iotdevice/transport"
+	"github.com/amenzhinsky/iothub/logger"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+// TransportOption is a transport configuration option.
+type TransportOption func(tr *Transport)
+
+// WithLogger sets logger for errors and warnings
+// plus debug messages when it's enabled.
+func WithLogger(l logger.Logger) TransportOption {
+	return func(tr *Transport) {
+		tr.logger = l
+	}
+}
+
+// WithClient sets client to use for HTTP requests.
+func WithClient(c *http.Client) TransportOption {
+	return func(tr *Transport) {
+		tr.client = c
+	}
+}
+
+type Transport struct {
+	logger logger.Logger
+	client *http.Client
+	creds  transport.Credentials
+}
+
+// New returns new Transport transport.
+func New(opts ...TransportOption) *Transport {
+	tr := &Transport{
+		client: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		opt(tr)
+	}
+	return tr
+}
+
+func (tr *Transport) SetLogger(logger logger.Logger) {
+	tr.logger = logger
+}
+
+func (tr *Transport) Connect(ctx context.Context, creds transport.Credentials) error {
+	tr.creds = creds
+	return nil
+}
+
+func (tr *Transport) Send(ctx context.Context, msg *common.Message) error {
+	return ErrNotImplemented
+}
+
+func (tr *Transport) RegisterDirectMethods(ctx context.Context, mux transport.MethodDispatcher) error {
+	return ErrNotImplemented
+}
+
+func (tr *Transport) SubscribeEvents(ctx context.Context, mux transport.MessageDispatcher) error {
+	return ErrNotImplemented
+}
+
+func (tr *Transport) SubscribeTwinUpdates(ctx context.Context, mux transport.TwinStateDispatcher) error {
+	return ErrNotImplemented
+}
+
+func (tr *Transport) RetrieveTwinProperties(ctx context.Context) (payload []byte, err error) {
+	return nil, ErrNotImplemented
+}
+
+func (tr *Transport) UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error) {
+	return 0, ErrNotImplemented
+}
+
+func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error) {
+	payload := CreateFileUploadRequest{
+		BlobName: blobName,
+	}
+	body, err := json.Marshal(&payload)
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://localhost:443/devices/%s/files", tr.creds.GetDeviceID()), bytes.NewReader(body))
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := tr.client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	var response CreateFileUploadResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return "", "", err
+	}
+
+	return response.CorrelationID, response.SASURI(), nil
+}
+
+func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader) error {
+	req, err := http.NewRequest(http.MethodPut, sasURI, file)
+	if err != nil {
+		return err
+	}
+
+	_, err = tr.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Check response body, code
+
+	return nil
+}
+
+func (tr *Transport) Close() error {
+	// NOOP
+	return nil
+}

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -18,7 +18,7 @@ func (r *CreateFileUploadResponse) SASURI() string {
 	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, r.ContainerName, r.BlobName, r.SASToken)
 }
 
-type NotifyUploadRequest struct {
+type NotifyFileUploadRequest struct {
 	CorrelationID     string `json:"correlationId`
 	IsSuccess         bool   `json:"isSuccess"`
 	StatusCode        int    `json:"statusCode"`

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -5,11 +5,11 @@ import (
 	"net/url"
 )
 
-type CreateFileUploadRequest struct {
+type BlobSharedAccessSignatureRequest struct {
 	BlobName string `json:"blobName"`
 }
 
-type CreateFileUploadResponse struct {
+type BlobSharedAccessSignatureResponse struct {
 	CorrelationID string `json:"correlationId"`
 	HostName      string `json:"hostName"`
 	ContainerName string `json:"containerName"`
@@ -17,11 +17,11 @@ type CreateFileUploadResponse struct {
 	SASToken      string `json:"sasToken"`
 }
 
-func (r *CreateFileUploadResponse) SASURI() string {
+func (r *BlobSharedAccessSignatureResponse) SASURI() string {
 	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, url.PathEscape(r.ContainerName), url.PathEscape(r.BlobName), r.SASToken)
 }
 
-type NotifyFileUploadRequest struct {
+type NotifyUploadCompleteRequest struct {
 	IsSuccess         bool   `json:"isSuccess"`
 	StatusCode        int    `json:"statusCode"`
 	StatusDescription string `json:"statusDescription"`

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -24,3 +24,8 @@ type NotifyFileUploadRequest struct {
 	StatusCode        int    `json:"statusCode"`
 	StatusDescription string `json:"statusDescription"`
 }
+
+type ErrorResponse struct {
+	Message          string
+	ExceptionMessage string
+}

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -18,7 +18,7 @@ type BlobSharedAccessSignatureResponse struct {
 }
 
 func (r *BlobSharedAccessSignatureResponse) SASURI() string {
-	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, url.PathEscape(r.ContainerName), url.PathEscape(r.BlobName), r.SASToken)
+	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, r.ContainerName, url.PathEscape(r.BlobName), r.SASToken)
 }
 
 type NotifyUploadCompleteRequest struct {

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -1,6 +1,9 @@
 package http
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
 type CreateFileUploadRequest struct {
 	BlobName string `json:"blobName"`
@@ -15,11 +18,10 @@ type CreateFileUploadResponse struct {
 }
 
 func (r *CreateFileUploadResponse) SASURI() string {
-	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, r.ContainerName, r.BlobName, r.SASToken)
+	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, url.PathEscape(r.ContainerName), url.PathEscape(r.BlobName), r.SASToken)
 }
 
 type NotifyFileUploadRequest struct {
-	CorrelationID     string `json:"correlationId`
 	IsSuccess         bool   `json:"isSuccess"`
 	StatusCode        int    `json:"statusCode"`
 	StatusDescription string `json:"statusDescription"`

--- a/iotdevice/transport/http/messages.go
+++ b/iotdevice/transport/http/messages.go
@@ -1,0 +1,26 @@
+package http
+
+import "fmt"
+
+type CreateFileUploadRequest struct {
+	BlobName string `json:"blobName"`
+}
+
+type CreateFileUploadResponse struct {
+	CorrelationID string `json:"correlationId"`
+	HostName      string `json:"hostName"`
+	ContainerName string `json:"containerName"`
+	BlobName      string `json:"blobName"`
+	SASToken      string `json:"sasToken"`
+}
+
+func (r *CreateFileUploadResponse) SASURI() string {
+	return fmt.Sprintf("https://%s/%s/%s%s", r.HostName, r.ContainerName, r.BlobName, r.SASToken)
+}
+
+type NotifyUploadRequest struct {
+	CorrelationID     string `json:"correlationId`
+	IsSuccess         bool   `json:"isSuccess"`
+	StatusCode        int    `json:"statusCode"`
+	StatusDescription string `json:"statusDescription"`
+}

--- a/iotdevice/transport/mqtt/mqtt.go
+++ b/iotdevice/transport/mqtt/mqtt.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -565,4 +566,12 @@ func (tr *Transport) Close() error {
 		tr.logger.Debugf("disconnected")
 	}
 	return nil
+}
+
+func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error) {
+	return "", "", fmt.Errorf("unavailable in the MQTT transport")
+}
+
+func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader) error {
+	return fmt.Errorf("unavailable in the MQTT transport")
 }

--- a/iotdevice/transport/mqtt/mqtt.go
+++ b/iotdevice/transport/mqtt/mqtt.go
@@ -568,10 +568,17 @@ func (tr *Transport) Close() error {
 	return nil
 }
 
+// GetBlobSharedAccessSignature is not available in the MQTT transport.
 func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error) {
 	return "", "", fmt.Errorf("unavailable in the MQTT transport")
 }
 
+// UploadFile is not available in the MQTT transport.
 func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader) error {
+	return fmt.Errorf("unavailable in the MQTT transport")
+}
+
+// NotifyFileUpload is not available in the MQTT transport.
+func (tr *Transport) NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
 	return fmt.Errorf("unavailable in the MQTT transport")
 }

--- a/iotdevice/transport/mqtt/mqtt.go
+++ b/iotdevice/transport/mqtt/mqtt.go
@@ -574,7 +574,7 @@ func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName 
 }
 
 // UploadFile is not available in the MQTT transport.
-func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader) error {
+func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader, size int64) error {
 	return fmt.Errorf("unavailable in the MQTT transport")
 }
 

--- a/iotdevice/transport/mqtt/mqtt.go
+++ b/iotdevice/transport/mqtt/mqtt.go
@@ -573,12 +573,12 @@ func (tr *Transport) GetBlobSharedAccessSignature(ctx context.Context, blobName 
 	return "", "", fmt.Errorf("unavailable in the MQTT transport")
 }
 
-// UploadFile is not available in the MQTT transport.
-func (tr *Transport) UploadFile(ctx context.Context, sasURI string, file io.Reader, size int64) error {
+// UploadToBlob is not available in the MQTT transport.
+func (tr *Transport) UploadToBlob(ctx context.Context, sasURI string, file io.Reader, size int64) error {
 	return fmt.Errorf("unavailable in the MQTT transport")
 }
 
-// NotifyFileUpload is not available in the MQTT transport.
-func (tr *Transport) NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
+// NotifyUploadComplete is not available in the MQTT transport.
+func (tr *Transport) NotifyUploadComplete(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error {
 	return fmt.Errorf("unavailable in the MQTT transport")
 }

--- a/iotdevice/transport/transport.go
+++ b/iotdevice/transport/transport.go
@@ -21,8 +21,8 @@ type Transport interface {
 	RetrieveTwinProperties(ctx context.Context) (payload []byte, err error)
 	UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error)
 	GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error)
-	UploadFile(ctx context.Context, sasURI string, file io.Reader, size int64) error
-	NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error
+	UploadToBlob(ctx context.Context, sasURI string, file io.Reader, size int64) error
+	NotifyUploadComplete(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error
 	Close() error
 }
 

--- a/iotdevice/transport/transport.go
+++ b/iotdevice/transport/transport.go
@@ -21,7 +21,7 @@ type Transport interface {
 	RetrieveTwinProperties(ctx context.Context) (payload []byte, err error)
 	UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error)
 	GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error)
-	UploadFile(ctx context.Context, sasURI string, file io.Reader) error
+	UploadFile(ctx context.Context, sasURI string, file io.Reader, size int64) error
 	NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error
 	Close() error
 }

--- a/iotdevice/transport/transport.go
+++ b/iotdevice/transport/transport.go
@@ -22,6 +22,7 @@ type Transport interface {
 	UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error)
 	GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error)
 	UploadFile(ctx context.Context, sasURI string, file io.Reader) error
+	NotifyFileUpload(ctx context.Context, correlationID string, success bool, statusCode int, statusDescription string) error
 	Close() error
 }
 

--- a/iotdevice/transport/transport.go
+++ b/iotdevice/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"time"
 
 	"github.com/amenzhinsky/iothub/common"
@@ -19,6 +20,8 @@ type Transport interface {
 	SubscribeTwinUpdates(ctx context.Context, mux TwinStateDispatcher) error
 	RetrieveTwinProperties(ctx context.Context) (payload []byte, err error)
 	UpdateTwinProperties(ctx context.Context, payload []byte) (version int, err error)
+	GetBlobSharedAccessSignature(ctx context.Context, blobName string) (string, string, error)
+	UploadFile(ctx context.Context, sasURI string, file io.Reader) error
 	Close() error
 }
 

--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -164,6 +164,7 @@ func (c *Client) putTokenContinuously(ctx context.Context, conn *amqp.Client) er
 	}
 
 	if err := c.putToken(ctx, sess, tokenUpdateInterval); err != nil {
+		fmt.Printf("FAiled: %v\n", err)
 		_ = sess.Close(context.Background())
 		return err
 	}
@@ -213,6 +214,8 @@ func (c *Client) putToken(
 	if err != nil {
 		return err
 	}
+
+	fmt.Println("11111 sending")
 	if err = send.Send(ctx, &amqp.Message{
 		Value: sas.String(),
 		Properties: &amqp.MessageProperties{
@@ -227,14 +230,17 @@ func (c *Client) putToken(
 	}); err != nil {
 		return err
 	}
+	fmt.Println("2222 sent")
 
 	msg, err := recv.Receive(ctx)
 	if err != nil {
 		return err
 	}
+	fmt.Println("3333 received")
 	if err = recv.AcceptMessage(ctx, msg); err != nil {
 		return err
 	}
+	fmt.Println("4444 checking")
 	return eventhub.CheckMessageResponse(msg)
 }
 
@@ -511,8 +517,6 @@ type Feedback struct {
 }
 
 // FileNotification is emitted once a blob file is uploaded to the hub.
-//
-// TODO: structure is yet to define.
 type FileNotification struct {
 	*amqp.Message
 }


### PR DESCRIPTION
Implement File Upload over HTTP according to https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/iot-hub/iot-hub-devguide-file-upload.md#device-initialize-a-file-upload.

Device:
* Implements a new HTTP transport with support for the file-related APIs
  * Initialize a file upload
  * Upload file using Azure storage APIs
  * Notify IoT Hub of a completed file upload

Service:
* Implements proper support for watching for file notifications 

Closes #56 

To test:

Set up an Azure IoTHub and an Azure Storage Account. Configure File Upload for the IoTHub to use the Storage Account.

```sh
go build -o iot-device cmd/iothub-device/main.go
go build -o iot-service cmd/iothub-service/main.go
```

Then, in one terminal:
```sh
export IOTHUB_SERVICE_CONNECTION_STRING="xxx"
./iot-service watch-file-notifications
```

In another terminal, upload a file:
```sh
export IOTHUB_DEVICE_CONNECTION_STRING="xxx"
./iot-device -transport http file-upload ./path/to/file.txt
```

After a few seconds the file notification will be printed.

```json
{
	"deviceId": "my-device",
	"blobUri": "https://my-blob.blob.core.windows.net/iothub/my-device/file.txt",
	"blobName": "file.txt",
	"lastUpdatedTime": "2021-11-15T12:50:31Z",
	"blobSizeInBytes": 6,
	"enqueuedTimeUtc": "2021-11-15T12:50:32.3018639Z"
}
```