### PR TITLE
Upgrade to go-amqp v0.17.0

### DIFF
--- a/eventhub/client.go
+++ b/eventhub/client.go
@@ -252,7 +252,7 @@ func (c *Client) getPartitionIDs(ctx context.Context, sess *amqp.Session) ([]str
 	if err := send.Send(ctx, &amqp.Message{
 		Properties: &amqp.MessageProperties{
 			MessageID: mid,
-			ReplyTo:   replyTo,
+			ReplyTo:   &replyTo,
 		},
 		ApplicationProperties: map[string]interface{}{
 			"operation": "READ",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/amenzhinsky/iothub
 go 1.17
 
 require (
-	github.com/Azure/go-amqp v0.16.1
+	github.com/Azure/go-amqp v0.17.0
 	github.com/eclipse/paho.mqtt.golang v1.3.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/go-amqp v0.16.1 h1:HAvanc2J+NCj7WXS3vAzy0YvZ7TR8sJrS7iVNHokUgs=
-github.com/Azure/go-amqp v0.16.1/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
+github.com/Azure/go-amqp v0.17.0 h1:HHXa3149nKrI0IZwyM7DRcRy5810t9ZICDutn4BYzj4=
+github.com/Azure/go-amqp v0.17.0/go.mod h1:9YJ3RhxRT1gquYnzpZO1vcYMMpAdJT+QEg6fwmw9Zlg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
@@ -16,12 +16,16 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 h1:Jcxah/M+oLZ/R4/z5RzfPzGbPXnVDPkEDtf2JnuxN+U=
 golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/iotservice/client.go
+++ b/iotservice/client.go
@@ -214,11 +214,13 @@ func (c *Client) putToken(
 		return err
 	}
 
+	to := "$cbs"
+	replyTo := "cbs"
 	if err = send.Send(ctx, &amqp.Message{
 		Value: sas.String(),
 		Properties: &amqp.MessageProperties{
-			To:      "$cbs",
-			ReplyTo: "cbs",
+			To:      &to,
+			ReplyTo: &replyTo,
 		},
 		ApplicationProperties: map[string]interface{}{
 			"operation": "put-token",

--- a/iotservice/message.go
+++ b/iotservice/message.go
@@ -26,8 +26,10 @@ func FromAMQPMessage(msg *amqp.Message) *common.Message {
 		if msg.Properties.CorrelationID != nil {
 			m.CorrelationID = msg.Properties.CorrelationID.(string)
 		}
-		m.To = msg.Properties.To
-		m.ExpiryTime = &msg.Properties.AbsoluteExpiryTime
+		if msg.Properties.To != nil {
+			m.To = *msg.Properties.To
+		}
+		m.ExpiryTime = msg.Properties.AbsoluteExpiryTime
 	}
 	for k, v := range msg.Annotations {
 		switch k {
@@ -75,11 +77,11 @@ func toAMQPMessage(msg *common.Message) *amqp.Message {
 	return &amqp.Message{
 		Data: [][]byte{msg.Payload},
 		Properties: &amqp.MessageProperties{
-			To:                 msg.To,
+			To:                 &msg.To,
 			UserID:             []byte(msg.UserID),
 			MessageID:          msg.MessageID,
 			CorrelationID:      msg.CorrelationID,
-			AbsoluteExpiryTime: expiryTime,
+			AbsoluteExpiryTime: &expiryTime,
 		},
 		ApplicationProperties: props,
 	}


### PR DESCRIPTION
Yet again [go-amqp](https://github.com/Azure/go-amqp) has introduced breaking changes in a minor, which causes this library to be incompatible with libraries using the newer version of go-amqp.

Upgrading this library to use the latest available version of the go-amqp library should fix this issue.